### PR TITLE
Fix include definitions subfolders

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -126,7 +126,7 @@ exports.bundle = function (options) {
     console.log('Adding definitions to spec');
     if (swagger.definitions)
       throw Error('All definitions should be defined inside ' + definitionsDir);
-    swagger.definitions = globYamlObject(definitionsDir, baseName);
+    swagger.definitions = globYamlObject(definitionsDir, fileName);
   }
 
   if (!options.skipCodeSamples && dirExist(codeSamplesDir)) {
@@ -255,6 +255,10 @@ function inlineHeaders(swagger) {
 
 function baseName(path) {
   return Path.parse(path).name;
+}
+
+function fileName(path) {
+  return path.replace(/\.yaml|\'/ig, '');
 }
 
 function filenameToPath(filename) {


### PR DESCRIPTION
With this fix you will be able to:
Inside the definitions folders you can create multiple folders to split the documentation.

For example:

/Definitions
-/Definitions/v1/Some.yaml
-/Definitions/v2/Some.yaml

In the past you will get There is already a defined collection.
