### PR TITLE
Update swagger-repo.js

### DIFF
--- a/bin/swagger-repo.js
+++ b/bin/swagger-repo.js
@@ -43,7 +43,7 @@ program
   .description('Builds the static assets and puts it ')
   .option('-b, --basedir <relpath>', 'The output file')
   .option('-o, --outdir <dirname>', 'The output directory, web_deploy by default')
-  .option('-s, --skipCodeSamples <skipCodeSamples>', 'Don\'t include the code samples')
+  .option('-s, --skipCodeSamples', 'Don\'t include the code samples')
   .action(function(options) {
     const config = api.readConfig();
 

--- a/bin/swagger-repo.js
+++ b/bin/swagger-repo.js
@@ -43,6 +43,7 @@ program
   .description('Builds the static assets and puts it ')
   .option('-b, --basedir <relpath>', 'The output file')
   .option('-o, --outdir <dirname>', 'The output directory, web_deploy by default')
+  .option('-s, --skipCodeSamples <skipCodeSamples>', 'Don\'t include the code samples')
   .action(function(options) {
     const config = api.readConfig();
 


### PR DESCRIPTION
If you choose not to generate the code samples at creation time you are unable to build, as by default, the build process expects the samples to exist.

An option flag existed in the lib to skip but there was no way to pass the option from the CLI. This change adds the option to skip to the CLI.

Could have been solved with a check to see if the code samples exist in the lib, however this simple change was sufficient to complete my task and did not introduce additional logic.