### PR TITLE
Exit with non-zero return code if deploy fails

### DIFF
--- a/bin/swagger-repo.js
+++ b/bin/swagger-repo.js
@@ -111,6 +111,7 @@ program
     ghpages.publish('web_deploy', publishOpts, async function(err) {
       if (err) {
         console.log(chalk.red('Deploy failed: ') + err);
+        process.exit(1);
       }
       console.log(chalk.green('🎉  Deployed successfully!'));
       if (options.preview && process.env.TRAVIS_BRANCH) {


### PR DESCRIPTION
Implement expected behaviour, as it creates a clear signal that something went wrong when used in a CI/CD system (Which is our case)