### PR TITLE
fix #19 support path with dot

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -450,7 +450,7 @@ function filenameToPath(filename) {
   return '/' + filename.replace(/@/g, '/');
 }
 
-function globObject(dir, pattern, objectPathCb) {
+function globObject(dir, pattern, objectPathCb, supportPathWithDot = false) {
   return _.reduce(
     glob(Path.join(dir, pattern)),
     function(result, path) {
@@ -458,7 +458,7 @@ function globObject(dir, pattern, objectPathCb) {
       if (_.has(result, objPath)) {
         throw new Error(objPath + ' definition already exists');
       }
-      _.set(result, objPath, path);
+      _.set(result, supportPathWithDot ? [`${objPath}`] : objPath, path);
 
       return result;
     },
@@ -467,11 +467,11 @@ function globObject(dir, pattern, objectPathCb) {
 }
 
 function globYamlObject(dir, objectPathCb) {
-  return _.mapValues(globObject(dir, anyYaml, objectPathCb), readYaml);
+  return _.mapValues(globObject(dir, anyYaml, objectPathCb, true), readYaml);
 }
 
 function updateGlobObject(dir, object) {
-  const knownKeys = globObject(dir, anyYaml, baseName);
+  const knownKeys = globObject(dir, anyYaml, baseName, true);
 
   _.each(object, function(value, key) {
     let filename = Path.join(dir, key + '.yaml');


### PR DESCRIPTION
fix #19

When the filename was `x.y.z.yaml` the swagger validation was failing. It is coming from the lodash function `_.set` that serialize the `.` as a sub object, check https://github.com/lodash/lodash/issues/3529