### PR TITLE
fix: update link to the create-openapi-repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Opionated CLI tool to help you manage your OpenAPI(fka Swagger) repo.
 
-Used by [generator-openapi-repo](https://github.com/Rebilly/generator-openapi-repo)
+Used by [create-openapi-repo](https://github.com/Redocly/create-openapi-repo)


### PR DESCRIPTION
Changes the link (and its text)to the create-openapi-repo as the repository was transferred to the Redocly organization and renamed.